### PR TITLE
bugfix: Making sure that when prettier fail to parse buffer we do not

### DIFF
--- a/autoload/prettier.vim
+++ b/autoload/prettier.vim
@@ -10,6 +10,12 @@ function! prettier#Prettier() abort
   if exec != -1
     let l:stdout = split(system(exec . s:Get_Prettier_Exec_Args(), getbufline(bufnr('%'), 1, '$')), '\n')
 
+    " check system exit code
+    if v:shell_error
+      echohl WarningMsg | echom 'Prettier: failed to parse buffer.' | echohl NONE
+      return
+    endif
+
     " delete all lines on the current buffer
     silent! execute 1 . ',' . line('$') . 'delete _'
 


### PR DESCRIPTION
Making sure we check the system exit code before overwriting the buffer. In case of error we can display an error message.

fixes: https://github.com/mitermayer/vim-prettier/issues/2
