### PR TITLE
Adding support for async formating and making it default for autosave

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ vim-prettier executable resolution:
 
 Formats the entire buffer
 
+### Commands
+
+Prettier can be manualy triggered by:
+
+```
+<Leader>p
+```
+
+### Configuration
+
 ```
 :Prettier
 ```


### PR DESCRIPTION
Add support for async formatting, make the default autosave behaviour use the async formating. 


implements https://github.com/mitermayer/vim-prettier/issues/4 