### PR TITLE
Fix default settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ autocmd BufWritePre,TextChanged,InsertLeave *.js,*.css,*.scss,*.less PrettierAsy
 
 ### Overwrite default prettier configuration
 
+**Note:** vim-prettier default settings differ from prettier intentionally. The default settings used on vim-prettier are meant to follow the same defaults that is used internally at Facebook and on Facebook open source projects.
+
 ```vim
 " max line lengh that prettier will wrap on
 g:prettier#config#print_width = 80

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -94,7 +94,9 @@ Running before saving, changing text or leaving insert mode:
 <
 Overwrite default prettier configuration
 
-Note: vim-prettier default settings differ from prettier intentionally. The default settings used on vim-prettier are meant to follow the same defaults that is used internally at Facebook and on Facebook open source projects.
+Note: vim-prettier default settings differ from prettier intentionally.
+The default settings used on vim-prettier are meant to follow the same
+defaults that is used internally at Facebook and on Facebook open source projects.
 >
   " max line lengh that prettier will wrap on
   g:prettier#config#print_width = 80

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -93,6 +93,8 @@ Running before saving, changing text or leaving insert mode:
   autocmd BufWritePre,TextChanged,InsertLeave *.js,*.css,*.scss,*.less PrettierAsync
 <
 Overwrite default prettier configuration
+
+Note: vim-prettier default settings differ from prettier intentionally. The default settings used on vim-prettier are meant to follow the same defaults that is used internally at Facebook and on Facebook open source projects.
 >
   " max line lengh that prettier will wrap on
   g:prettier#config#print_width = 80


### PR DESCRIPTION
This PR aligns the default settings for `prettier` based on the [current settings](https://github.com/prettier/prettier#options) specified in the `prettier` repo.