### PR TITLE
Add JSON/GraphQL parser (prettier 1.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ g:prettier#config#jsx_bracket_same_line = 'true'
 " none|es5|all
 g:prettier#config#trailing_comma = 'all'
 
-" flow|babylon|typescript|postcss|json
+" flow|babylon|typescript|postcss|json|graphql
 g:prettier#config#parser = 'flow'
 
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A vim plugin wrapper for prettier, pre-configured with custom default prettier settings.
 
-By default it will auto format **javascript**, **typescript**, **less**, **scss**, **css**, and **json** files that have "@format" annotation in the header of the file.
+By default it will auto format **javascript**, **typescript**, **less**, **scss**, **css**, **json**, and **graphql** files that have "@format" annotation in the header of the file.
 
 ![vim-prettier](/media/vim-prettier.gif?raw=true "vim-prettier")
 
@@ -14,7 +14,7 @@ Install with [vim-plug](https://github.com/junegunn/vim-plug), assumes node and 
 " post install (yarn install | npm install) then load plugin only for editing supported files
 Plug 'mitermayer/vim-prettier', { 
 	\ 'do': 'yarn install', 
-	\ 'for': ['javascript', 'typescript', 'css', 'less', 'scss', 'json'] } 
+	\ 'for': ['javascript', 'typescript', 'css', 'less', 'scss', 'json', 'graphql'] } 
 ```
 
 If using other vim plugin managers or doing manual setup make sure to have `prettier` installed globally or go to your vim-prettier directory and either do `npm install` or `yarn install`
@@ -75,14 +75,14 @@ Running before saving sync:
 
 ```vim
 let g:prettier#autoformat = 0
-autocmd BufWritePre *.js,*.json,*.css,*.scss,*.less Prettier
+autocmd BufWritePre *.js,*.json,*.css,*.scss,*.less,*.graphql Prettier
 ```
 
 Running before saving async (vim 8+):
 
 ```vim
 let g:prettier#autoformat = 0
-autocmd BufWritePre *.js,*.json,*.css,*.scss,*.less PrettierAsync
+autocmd BufWritePre *.js,*.json,*.css,*.scss,*.less,*.graphql PrettierAsync
 ```
 
 Running before saving, changing text or leaving insert mode: 
@@ -92,7 +92,7 @@ Running before saving, changing text or leaving insert mode:
 let g:prettier#quickfix_enabled = 0
 
 let g:prettier#autoformat = 0
-autocmd BufWritePre,TextChanged,InsertLeave *.js,*.json,*.css,*.scss,*.less PrettierAsync
+autocmd BufWritePre,TextChanged,InsertLeave *.js,*.json,*.css,*.scss,*.less,*.graphql PrettierAsync
 ```
 
 ### Overwrite default prettier configuration

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A vim plugin wrapper for prettier, pre-configured with custom default prettier settings.
 
-By default it will auto format **javascript**, **typescript**, **less**, **scss** and **css** files that have "@format" annotation in the header of the file.
+By default it will auto format **javascript**, **typescript**, **less**, **scss**, **css**, and **json** files that have "@format" annotation in the header of the file.
 
 ![vim-prettier](/media/vim-prettier.gif?raw=true "vim-prettier")
 
@@ -14,7 +14,7 @@ Install with [vim-plug](https://github.com/junegunn/vim-plug), assumes node and 
 " post install (yarn install | npm install) then load plugin only for editing supported files
 Plug 'mitermayer/vim-prettier', { 
 	\ 'do': 'yarn install', 
-	\ 'for': ['javascript', 'typescript', 'css', 'less', 'scss'] } 
+	\ 'for': ['javascript', 'typescript', 'css', 'less', 'scss', 'json'] } 
 ```
 
 If using other vim plugin managers or doing manual setup make sure to have `prettier` installed globally or go to your vim-prettier directory and either do `npm install` or `yarn install`
@@ -75,14 +75,14 @@ Running before saving sync:
 
 ```vim
 let g:prettier#autoformat = 0
-autocmd BufWritePre *.js,*.css,*.scss,*.less Prettier
+autocmd BufWritePre *.js,*.json,*.css,*.scss,*.less Prettier
 ```
 
 Running before saving async (vim 8+):
 
 ```vim
 let g:prettier#autoformat = 0
-autocmd BufWritePre *.js,*.css,*.scss,*.less PrettierAsync
+autocmd BufWritePre *.js,*.json,*.css,*.scss,*.less PrettierAsync
 ```
 
 Running before saving, changing text or leaving insert mode: 
@@ -92,7 +92,7 @@ Running before saving, changing text or leaving insert mode:
 let g:prettier#quickfix_enabled = 0
 
 let g:prettier#autoformat = 0
-autocmd BufWritePre,TextChanged,InsertLeave *.js,*.css,*.scss,*.less PrettierAsync
+autocmd BufWritePre,TextChanged,InsertLeave *.js,*.json,*.css,*.scss,*.less PrettierAsync
 ```
 
 ### Overwrite default prettier configuration
@@ -122,7 +122,7 @@ g:prettier#config#jsx_bracket_same_line = 'true'
 " none|es5|all
 g:prettier#config#trailing_comma = 'all'
 
-" flow|babylon|typescript|postcss
+" flow|babylon|typescript|postcss|json
 g:prettier#config#parser = 'flow'
 
 ```

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -15,7 +15,7 @@ A vim plugin wrapper for prettier, pre-configured with
 custom default prettier settings.
 
 By default it will auto format javascript, typescript, less, scss, css,
-and json files that have '@format' annotation in the header of the file.
+json, and graphql files that have '@format' annotation in the header of the file.
 
 When installed via vim-plug, a default prettier executable is installed inside
  vim-prettier.
@@ -34,7 +34,7 @@ node and yarn|npm installed globally.
 >
   Plug 'mitermayer/vim-prettier', { 
 	\ 'do': 'yarn install', 
-	\ 'for': ['javascript', 'typescript', 'css', 'less', 'scss', 'json'] } 
+	\ 'for': ['javascript', 'typescript', 'css', 'less', 'scss', 'json', 'graphql'] } 
 <
 If using other vim plugin managers or doing manual setup make sure to have 
 `prettier` installed globally or go to your vim-prettier directory and 
@@ -77,12 +77,12 @@ First disable the default autoformat, then update to your own custom behaviour
 Running before saving sync:
 >
   let g:prettier#autoformat = 0
-  autocmd BufWritePre *.js,*.json,*.css,*.scss,*.less Prettier
+  autocmd BufWritePre *.js,*.json,*.css,*.scss,*.less,*.graphql Prettier
 <
 Running before saving async (vim 8+):
 >
   let g:prettier#autoformat = 0
-  autocmd BufWritePre *.js,*.json,*.css,*.scss,*.less PrettierAsync
+  autocmd BufWritePre *.js,*.json,*.css,*.scss,*.less,*.graphql PrettierAsync
 <
 Running before saving, changing text or leaving insert mode: 
 >
@@ -90,7 +90,7 @@ Running before saving, changing text or leaving insert mode:
   " when running at every change you may want to disable quickfix
   let g:prettier#quickfix_enabled = 0
 
-  autocmd BufWritePre,TextChanged,InsertLeave *.js,*.json,*.css,*.scss,*.less PrettierAsync
+  autocmd BufWritePre,TextChanged,InsertLeave *.js,*.json,*.css,*.scss,*.less,*.graphql PrettierAsync
 <
 Overwrite default prettier configuration
 >

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -14,8 +14,8 @@ INTRODUCTION                                        *vim-prettier-introduction*
 A vim plugin wrapper for prettier, pre-configured with 
 custom default prettier settings.
 
-By default it will auto format javascript, typescript, less, scss and 
-css files that have '@format' annotation in the header of the file.
+By default it will auto format javascript, typescript, less, scss, css,
+and json files that have '@format' annotation in the header of the file.
 
 When installed via vim-plug, a default prettier executable is installed inside
  vim-prettier.
@@ -34,7 +34,7 @@ node and yarn|npm installed globally.
 >
   Plug 'mitermayer/vim-prettier', { 
 	\ 'do': 'yarn install', 
-	\ 'for': ['javascript', 'typescript', 'css', 'less', 'scss'] } 
+	\ 'for': ['javascript', 'typescript', 'css', 'less', 'scss', 'json'] } 
 <
 If using other vim plugin managers or doing manual setup make sure to have 
 `prettier` installed globally or go to your vim-prettier directory and 
@@ -77,12 +77,12 @@ First disable the default autoformat, then update to your own custom behaviour
 Running before saving sync:
 >
   let g:prettier#autoformat = 0
-  autocmd BufWritePre *.js,*.css,*.scss,*.less Prettier
+  autocmd BufWritePre *.js,*.json,*.css,*.scss,*.less Prettier
 <
 Running before saving async (vim 8+):
 >
   let g:prettier#autoformat = 0
-  autocmd BufWritePre *.js,*.css,*.scss,*.less PrettierAsync
+  autocmd BufWritePre *.js,*.json,*.css,*.scss,*.less PrettierAsync
 <
 Running before saving, changing text or leaving insert mode: 
 >
@@ -90,7 +90,7 @@ Running before saving, changing text or leaving insert mode:
   " when running at every change you may want to disable quickfix
   let g:prettier#quickfix_enabled = 0
 
-  autocmd BufWritePre,TextChanged,InsertLeave *.js,*.css,*.scss,*.less PrettierAsync
+  autocmd BufWritePre,TextChanged,InsertLeave *.js,*.json,*.css,*.scss,*.less PrettierAsync
 <
 Overwrite default prettier configuration
 >
@@ -118,7 +118,7 @@ Overwrite default prettier configuration
   " none|es5|all
   g:prettier#config#trailing_comma = 'all'
 
-  " flow|babylon|typescript|postcss
+  " flow|babylon|typescript|postcss|json
   g:prettier#config#parser = 'flow'
 <
 ==============================================================================

--- a/doc/prettier.txt
+++ b/doc/prettier.txt
@@ -118,7 +118,7 @@ Overwrite default prettier configuration
   " none|es5|all
   g:prettier#config#trailing_comma = 'all'
 
-  " flow|babylon|typescript|postcss|json
+  " flow|babylon|typescript|postcss|json|graphql
   g:prettier#config#parser = 'flow'
 <
 ==============================================================================

--- a/ftplugin/graphql.vim
+++ b/ftplugin/graphql.vim
@@ -1,0 +1,10 @@
+let b:prettier_ft_default_args = {
+  \ 'parser': 'graphql'
+  \ }
+
+augroup Prettier
+  autocmd!
+  if g:prettier#autoformat
+    autocmd BufWritePre <buffer> call prettier#Autoformat()
+  endif
+augroup end

--- a/ftplugin/json.vim
+++ b/ftplugin/json.vim
@@ -1,0 +1,10 @@
+let b:prettier_ft_default_args = {
+  \ 'parser': 'json'
+  \ }
+
+augroup Prettier
+  autocmd!
+  if g:prettier#autoformat
+    autocmd BufWritePre <buffer> call prettier#Autoformat()
+  endif
+augroup end

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
     "url": "git://github.com/mitermayer/vim-prettier.git"
   },
   "dependencies": {
-    "prettier": "^1.4.4"
+    "prettier": "^1.5.2"
   }
 }

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -51,7 +51,7 @@ let g:prettier#config#jsx_bracket_same_line = get(g:,'prettier#config#jsx_bracke
 " none|es5|all
 let g:prettier#config#trailing_comma = get(g:,'prettier#config#trailing_comma', 'all')
 
-" flow|babylon|typescript|postcss
+" flow|babylon|typescript|postcss|json
 let g:prettier#config#parser = get(g:,'prettier#config#parser', 'flow')
 
 " synchronous by default

--- a/plugin/prettier.vim
+++ b/plugin/prettier.vim
@@ -51,7 +51,7 @@ let g:prettier#config#jsx_bracket_same_line = get(g:,'prettier#config#jsx_bracke
 " none|es5|all
 let g:prettier#config#trailing_comma = get(g:,'prettier#config#trailing_comma', 'all')
 
-" flow|babylon|typescript|postcss|json
+" flow|babylon|typescript|postcss|json|graphql
 let g:prettier#config#parser = get(g:,'prettier#config#parser', 'flow')
 
 " synchronous by default


### PR DESCRIPTION
This PR adds the `json` option as an option for the parser configuration (originally from #16 but extracted as a separate PR as a release with the `json` parser hasn't landed on `npm` yet.

TODO:
- [x] bump `prettier` version on `package.json`
- [x] test locally: command, autoformat, etc.