### PR TITLE
feature/add-filetype-support - Adding filetype detection support when

### DIFF
--- a/ftdetect/css.vim
+++ b/ftdetect/css.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufReadPost *.css setfiletype css

--- a/ftdetect/graphql.vim
+++ b/ftdetect/graphql.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufReadPost *.graphql,*.gql setfiletype graphql

--- a/ftdetect/javascript.vim
+++ b/ftdetect/javascript.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufReadPost *.js setfiletype javascript

--- a/ftdetect/json.vim
+++ b/ftdetect/json.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufReadPost *.json setfiletype json

--- a/ftdetect/less.vim
+++ b/ftdetect/less.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufReadPost *.less setfiletype less

--- a/ftdetect/scss.vim
+++ b/ftdetect/scss.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufReadPost *.scss setfiletype scss

--- a/ftdetect/typescript.vim
+++ b/ftdetect/typescript.vim
@@ -1,0 +1,1 @@
+autocmd BufNewFile,BufReadPost *.ts setfiletype typescript


### PR DESCRIPTION
We should provide some basic filetype detection but also keeping compatible with other plugins.

This for example would enable to correctly identify graphql, typescript, less, scss etc.. without having to rely on the filetype being implemented by other plugins.

Fixes: https://github.com/mitermayer/vim-prettier/issues/23