### PR TITLE
bugfix: json parser should not add extra comma to the end

### DIFF
--- a/ftplugin/json.vim
+++ b/ftplugin/json.vim
@@ -1,5 +1,6 @@
 let b:prettier_ft_default_args = {
-  \ 'parser': 'json'
+  \ 'parser': 'json',
+  \ 'trailingComma': 'none'
   \ }
 
 augroup Prettier


### PR DESCRIPTION
- adding extra comma to the end properties cause creates invalid json

fixes https://github.com/mitermayer/vim-prettier/issues/26